### PR TITLE
Closure conversion pass

### DIFF
--- a/hopper.cabal
+++ b/hopper.cabal
@@ -73,6 +73,7 @@ library
                     Hopper.Internal.Core.Literal
                     Hopper.Internal.LoweredCore.ANF
                     Hopper.Internal.Core.ShiftRemoval
+                    Hopper.Internal.LoweredCore.ClosureConversion
                     Hopper.Internal.LoweredCore.ClosureConvertedANF
                     Hopper.Internal.LoweredCore.EvalClosureConvertedANF
 

--- a/hopper.cabal
+++ b/hopper.cabal
@@ -106,6 +106,7 @@ library
                       ,lens >= 4.12 && < 4.14
                      --  ,ghc-typelits-natnormalise >= 0.4.1 && < 0.5
                       ,integer-gmp >= 1.0 && < 1.1
+                      ,dlist >= 0.7.1 && < 0.8
 
 
   -- Directories containing source files.

--- a/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
@@ -64,6 +64,18 @@ topEnvUse l = projectValue <$> get
     projectValue state = fromMaybe (error "impossible env stack underrun") $
       firstOf (topEnv.l) state
 
+allocClosureCodeId :: ConversionM ClosureCodeId
+allocClosureCodeId = do
+  curr <- use csNextClosureId
+  csNextClosureId %= succ
+  return curr
+
+allocThunkCodeId :: ConversionM ThunkCodeId
+allocThunkCodeId = do
+  curr <- use csNextThunkId
+  csNextThunkId %= succ
+  return curr
+
 -- TODO(bts): integrate real binder infos
 dummyBI :: BinderInfo
 dummyBI = BinderInfoData Omega () Nothing

--- a/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
@@ -54,9 +54,12 @@ data Reach
 -- node which replaces the lambda/delay in the AST.
 data EnvState
   = EnvState { _esVars  :: DL.DList Variable
-             -- ^ Environment vars allocated so far, for this closure/thunk
+             -- ^ Environment vars allocated so far, for this closure/thunk. We
+             -- use a DList so we can get O(1) 'snoc' (as opposed to building up
+             -- a list in reverse.)
              , _esInfos :: DL.DList BinderInfo
-             -- ^ Environment BinderInfos so far
+             -- ^ Environment BinderInfos so far. Similarly we use a DList here
+             -- for O(1) 'snoc'.
              , _esSize  :: EnvSize
              -- ^ Size of the environment so far, to avoid O(n) 'length' calls
              , _esSlots :: Map.Map Variable BinderSlot

--- a/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Hopper.Internal.LoweredCore.ClosureConversion
+  ( closureConvert
+  ) where
+
+import Hopper.Internal.LoweredCore.ANF
+import Hopper.Internal.LoweredCore.ClosureConvertedANF
+import Hopper.Internal.Type.BinderInfo (BinderInfo(..))
+import Hopper.Internal.Type.Relevance (Relevance(..))
+import Hopper.Utils.LocallyNameless
+
+import Control.Arrow (second)
+import Control.Lens (Lens', Traversal', (^.), (%~), (%=), _head, makeLenses,
+                     firstOf, over)
+import Control.Monad.Trans.State.Strict (State, runState, get)
+import Data.Function ((&))
+import Data.Maybe (fromMaybe)
+import Data.Word (Word32)
+
+import qualified Data.Map.Strict as Map
+
+data EnvState
+  = EnvState { _esVars  :: [Variable]
+             -- ^ Reversed env vars seen so far
+             , _esInfos :: [BinderInfo]
+             -- ^ Reversed env binder infos seen so far
+             , _esSize  :: Word32
+             -- ^ Size of the env so far, to avoid O(n) 'length' calls
+             }
+  deriving (Show)
+
+makeLenses ''EnvState
+
+type EnvStack = [EnvState]
+
+data ConversionState
+  = ConversionState { _csRegistry      :: SymbolRegistryCC
+                    , _csNextThunkId   :: ThunkCodeId
+                    , _csNextClosureId :: ClosureCodeId
+                    , _csEnvStack      :: EnvStack
+                    }
+  deriving (Show)
+
+makeLenses ''ConversionState
+
+type ConversionM = State ConversionState
+
+-- Some notes:
+--
+-- - "Closure height" refers to the number of lets passed since entering
+--   the closure or thunk. TODO(bts): possibly rename this?
+-- - Our implicit ABI is currently such that explicit closure args and captured
+--   env vars live on two separate levels, with env vars as the inner binding
+--   level. TODO(bts): update the evaluator to reflect this new ABI.
+
+topEnv :: Traversal' ConversionState EnvState
+topEnv = csEnvStack._head
+
+topEnvUse :: Lens' EnvState a -> ConversionM a
+topEnvUse l = projectValue <$> get
+  where
+    projectValue state = fromMaybe (error "impossible env stack underrun") $
+      firstOf (topEnv.l) state
+
+-- TODO(bts): integrate real binder infos
+dummyBI :: BinderInfo
+dummyBI = BinderInfoData Omega () Nothing
+
+adjustVar :: Word32 -> Variable -> ConversionM Variable
+adjustVar _closureHeight var@(GlobalVarSym _) = return var
+adjustVar closureHeight  var@(LocalVar lnv)
+  | depth > closureHeight  = capturedVar
+  | depth == closureHeight = bumpedVar   -- var refers to fn arg; bump past env
+  | otherwise              = return var
+
+  where
+    depth = lnv ^. lnDepth
+    slot = lnv ^. lnSlot
+
+    capturedVar :: ConversionM Variable
+    capturedVar = do
+      let envVarDepth = depth - closureHeight + 1
+          envVar = LocalVar $ LocalNamelessVar envVarDepth slot
+
+      envSlot <- BinderSlot <$> topEnvUse esSize
+
+      topEnv %= over esSize succ
+              . over esInfos (dummyBI:) -- TODO(bts): populate useful BinderInfo
+              . over esVars (envVar:)
+
+      return $ LocalVar $ LocalNamelessVar closureHeight envSlot
+
+    bumpedVar :: ConversionM Variable
+    bumpedVar = return $ var & localNameless.lnDepth %~ succ
+
+closureConvert :: Anf -> (AnfCC, SymbolRegistryCC)
+closureConvert anf0 = second _csRegistry $ runState (ccAnf 0 anf0) state0
+  where
+    state0 :: ConversionState
+    state0 = ConversionState (SymbolRegistryCC Map.empty Map.empty Map.empty)
+                             (ThunkCodeId 0)
+                             (ClosureCodeId 0)
+                             []
+
+    ccAnf :: Word32 -> Anf -> ConversionM AnfCC
+    ccAnf closureHeight (AnfReturn vars) =
+      ReturnCC <$> traverse (adjustVar closureHeight) vars
+
+    ccAnf closureHeight (AnfLet infos rhs body) = do
+      rhsCC <- ccRhs closureHeight rhs
+      bodyCC <- ccAnf (succ closureHeight) body
+      return $ LetNFCC infos rhsCC bodyCC
+
+    ccRhs :: Word32 -> Rhs -> ConversionM RhsCC
+    ccRhs closureHeight (RhsAlloc alloc) =
+      AllocRhsCC <$> ccAlloc closureHeight alloc
+
+    ccAlloc :: Word32 -> Alloc -> ConversionM AllocCC
+    ccAlloc _closureHeight (AllocLit lit) = return $ SharedLiteralCC lit

--- a/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConversion.hs
@@ -13,7 +13,7 @@ import Hopper.Utils.LocallyNameless
 
 import Control.Arrow (second)
 import Control.Lens (Lens', Traversal', (^.), (%~), (%=), _head, makeLenses,
-                     firstOf, over)
+                     firstOf, over, use)
 import Control.Monad.Trans.State.Strict (State, runState, get)
 import Data.Function ((&))
 import Data.Maybe (fromMaybe)

--- a/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric, LambdaCase,TypeOperators #-}
-
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Hopper.Internal.LoweredCore.ClosureConvertedANF(
   AnfCC(..)
@@ -67,10 +67,10 @@ maybe
 
 newtype ThunkCodeId =
     ThunkCodeId { unThunkCodeId :: Word64 }
-  deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
+  deriving(Enum,Eq,Ord,Read,Show,Typeable,Data,Generic)
 newtype ClosureCodeId =
     ClosureCodeId { unClosureCodeId :: Word64 }
-  deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
+  deriving(Enum,Eq,Ord,Read,Show,Typeable,Data,Generic)
 newtype EnvSize =
     EnvSize { getEnvSize :: Word64 }
   deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)

--- a/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
@@ -82,7 +82,7 @@ newtype EnvSize =
 makeLenses ''EnvSize
 
 newtype CodeArity =
-    CodeArity { getCodeArity :: Word64 }
+    CodeArity { getCodeArity :: Word32 }
   deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
 
 -- whether the binder position is a variable, wild card,
@@ -221,7 +221,7 @@ data AllocCC
         !ThunkCodeId -- thunk id for "code pointer" part of a closure
   | AllocateClosureCC
         !(V.Vector Variable) -- set of local variables captured in the thunk environment, in this order
-        !Word64 --- arity of closure (need that even be here?) TODO
+        !Word32 --- arity of closure (need that even be here?) TODO
         !ClosureCodeId -- the code id for the "code pointer" of a closure
   deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
 

--- a/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
@@ -221,7 +221,7 @@ data AllocCC
         !ThunkCodeId -- thunk id for "code pointer" part of a closure
   | AllocateClosureCC
         !(V.Vector Variable) -- set of local variables captured in the thunk environment, in this order
-        !Word32 --- arity of closure (need that even be here?) TODO
+        !CodeArity --- arity of closure (need that even be here?) TODO
         !ClosureCodeId -- the code id for the "code pointer" of a closure
   deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
 

--- a/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
+++ b/src/Hopper/Internal/LoweredCore/ClosureConvertedANF.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric, LambdaCase,TypeOperators #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Hopper.Internal.LoweredCore.ClosureConvertedANF(
   AnfCC(..)
@@ -20,7 +21,7 @@ module Hopper.Internal.LoweredCore.ClosureConvertedANF(
   ,RhsCC(..)
   ,ClosureCodeId(..)
   ,ThunkCodeId(..)
-  ,EnvSize(..) --- not sure if this is needed
+  ,EnvSize(..),envSize --- not sure if this is needed
   ,CodeArity(..) -- not sure if this is needed
    -- ,TypeCC(..) --- this shouldn't need to exist
   ,TransitiveLookup(..) -- this is a class reexport
@@ -28,11 +29,12 @@ module Hopper.Internal.LoweredCore.ClosureConvertedANF(
   ,ValueRepCC(..)
   ,ClosureCodeRecordCC(..)
   ,ThunkCodeRecordCC(..)
-  ,SymbolRegistryCC(..)
+  ,SymbolRegistryCC(..),symRegThunkMap,symRegClosureMap,symRegValueMap
   ,lookupThunkCodeId
   ,lookupClosureCodeId
   ) where
 
+import Control.Lens (makeLenses)
 import Data.Word
 import Data.Data
 import qualified Data.Map as Map-- FIXME, use IntMap or WordMap
@@ -66,14 +68,19 @@ maybe
 -}
 
 newtype ThunkCodeId =
-    ThunkCodeId { unThunkCodeId :: Word64 }
+    ThunkCodeId { _thunkCodeId :: Word64 }
   deriving(Enum,Eq,Ord,Read,Show,Typeable,Data,Generic)
+
 newtype ClosureCodeId =
-    ClosureCodeId { unClosureCodeId :: Word64 }
+    ClosureCodeId { _closureCodeId :: Word64 }
   deriving(Enum,Eq,Ord,Read,Show,Typeable,Data,Generic)
+
 newtype EnvSize =
-    EnvSize { getEnvSize :: Word64 }
-  deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
+    EnvSize { _envSize :: Word32 }
+  deriving(Enum,Eq,Ord,Read,Show,Typeable,Data,Generic)
+
+makeLenses ''EnvSize
+
 newtype CodeArity =
     CodeArity { getCodeArity :: Word64 }
   deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
@@ -110,8 +117,8 @@ data ValueRepCC ref =
   deriving (Eq,Ord,Show,Read,Typeable,Data,Generic)
 
 class CodeRecord a where
-  envSize :: a -> Word64
-  envBindersInfo :: a -> V.Vector BinderInfo
+  codeEnvSize :: a -> Word32
+  codeEnvBinderInfos :: a -> V.Vector BinderInfo
 
 data ThunkCodeRecordCC =
   ThunkCodeRecordCC
@@ -125,10 +132,10 @@ data ThunkCodeRecordCC =
   deriving (Eq,Ord,Read,Show,Typeable,Data,Generic)
 
 instance CodeRecord ThunkCodeRecordCC where
-  envSize (ThunkCodeRecordCC size _ _) = getEnvSize size
-  {-# INLINE envSize #-}
-  envBindersInfo (ThunkCodeRecordCC _ bs _) = bs
-  {-# INLINE envBindersInfo #-}
+  codeEnvSize (ThunkCodeRecordCC size _ _) = _envSize size
+  {-# INLINE codeEnvSize #-}
+  codeEnvBinderInfos (ThunkCodeRecordCC _ bs _) = bs
+  {-# INLINE codeEnvBinderInfos #-}
 
 {- |
 for now we pass all function args as references to boxed heap values,
@@ -150,10 +157,10 @@ data ClosureCodeRecordCC =
   deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
 
 instance CodeRecord ClosureCodeRecordCC where
-  envSize (ClosureCodeRecordCC size _ _ _ _) = getEnvSize size
-  {-# INLINE envSize #-}
-  envBindersInfo (ClosureCodeRecordCC _ bs _ _ _) = bs
-  {-# INLINE envBindersInfo #-}
+  codeEnvSize (ClosureCodeRecordCC size _ _ _ _) = _envSize size
+  {-# INLINE codeEnvSize #-}
+  codeEnvBinderInfos (ClosureCodeRecordCC _ bs _ _ _) = bs
+  {-# INLINE codeEnvBinderInfos #-}
 
 data AnfCC  =
     ReturnCC !(V.Vector Variable)
@@ -233,6 +240,7 @@ data SymbolRegistryCC =
                                         }
   deriving(Eq,Ord,Read,Show,Typeable,Data,Generic)
 
+makeLenses ''SymbolRegistryCC
 
 lookupClosureCodeId :: SymbolRegistryCC -> ClosureCodeId-> Either String ClosureCodeRecordCC
 lookupClosureCodeId (SymbolRegistryCC _thk closMap _vals) codeid =

--- a/src/Hopper/Internal/LoweredCore/EvalClosureConvertedANF.hs
+++ b/src/Hopper/Internal/LoweredCore/EvalClosureConvertedANF.hs
@@ -380,8 +380,8 @@ this will require analyzing core, and designing some sort of performance measure
 {-# SPECIALIZE compatibleEnv :: V.Vector a -> ClosureCodeRecordCC -> Bool #-}
 {-# SPECIALIZE compatibleEnv :: V.Vector a -> ThunkCodeRecordCC -> Bool #-}
 compatibleEnv :: CodeRecord r => V.Vector a -> r -> Bool
-compatibleEnv envRefs rec = refCount == V.length (envBindersInfo rec)
-                         && refCount == fromIntegral (envSize rec)
+compatibleEnv envRefs rec = refCount == V.length (codeEnvBinderInfos rec)
+                         && refCount == fromIntegral (codeEnvSize rec)
   where
     refCount = V.length envRefs
 

--- a/src/Hopper/Internal/LoweredCore/EvalClosureConvertedANF.hs
+++ b/src/Hopper/Internal/LoweredCore/EvalClosureConvertedANF.hs
@@ -317,7 +317,7 @@ enterClosureCC symbolReg env stack (LocalVar localvar, args) = do
         -- / unpack. We need to document / codify this.
         --
         -- TODO(joel/carter): make this explicit.
-        (EnvConsCC (closureenv V.++ argRefs) env)
+        (EnvConsCC closureenv (EnvConsCC argRefs env))
         (UpdateHeapRefCC ref stack)
         bod
     badVal ->

--- a/tests/HopSpec/AnfSpec.hs
+++ b/tests/HopSpec/AnfSpec.hs
@@ -33,6 +33,7 @@ spec =
           twenty = LInteger 20
           dummyBI = BinderInfoData Omega () Nothing
           prim0 = PrimopIdGeneral "test"
+          arity1 = V.singleton $ BinderInfoData Omega () Nothing
 
       describe "simple tail cases" $ do
         it "converts variables" $
@@ -45,14 +46,14 @@ spec =
         it "converts literals" $
           let lit = LInteger 42
               term = ELit lit
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsAlloc $ AllocLit lit)
                            (AnfReturn $ V.singleton v0)
           in toAnf term `shouldBe` anf
 
         it "converts returns" $
           let term = Return $ V.fromList [ELit ten, V v0]
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $ AllocLit ten)
                             (AnfReturn $ V.fromList [v0, v1])
            in toAnf term `shouldBe` anf
@@ -60,7 +61,7 @@ spec =
         it "converts delays" $
           let -- delay ((0) (0))
               term = Delay $ App (V v0) $ V.singleton (V v0)
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $
                               AllocThunk $
                                AnfTailCall $ AppFun v0 $ V.singleton v0)
@@ -72,9 +73,9 @@ spec =
               term = EnterThunk (Delay $ ELit ten)
               -- letA (delay (letA 10 in (0)))
               -- in   force (0)
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $
-                              AllocThunk (AnfLet (Arity 1)
+                              AllocThunk (AnfLet arity1
                                                  (RhsAlloc $ AllocLit ten)
                                                  (AnfReturn $ V.singleton v0)))
                             (AnfTailCall $ AppThunk v0)
@@ -92,7 +93,7 @@ spec =
 
         it "converts multi-arg tail calls" $
           let term = App (V v0) $ V.fromList [ELit ten, V v0]
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $ AllocLit ten)
                             (AnfTailCall $ AppFun v1
                                                   (V.fromList [v0, v1]))
@@ -100,7 +101,7 @@ spec =
 
         it "converts tail prim apps" $
           let term = PrimApp prim0 $ V.fromList [ELit ten, V v0]
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $ AllocLit ten)
                             (AnfTailCall $ AppPrim prim0
                                                    (V.fromList [v0, v1]))
@@ -109,8 +110,8 @@ spec =
         it "converts lambdas by introducing an allocation" $
           let term = Lam (V.singleton dummyBI)
                          (V v1)
-              anf = AnfLet (Arity 1)
-                           (RhsAlloc $ AllocLam (Arity 1)
+              anf = AnfLet arity1
+                           (RhsAlloc $ AllocLam arity1
                                                 (AnfReturn $ V.singleton v1))
                            (AnfReturn $ V.singleton v0)
           in toAnf term `shouldBe` anf
@@ -133,7 +134,7 @@ spec =
           let term = Let (V.singleton dummyBI)
                          (App (V abs) $ V.singleton $ V v0)
                          (App (V neg) $ V.singleton $ V v0)
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsApp $ AppFun abs $ V.singleton v0)
                            (AnfTailCall $ AppFun neg $ V.singleton v0)
           in toAnf term `shouldBe` anf
@@ -142,7 +143,7 @@ spec =
         it "converts variables bumped by a literal allocation" $
           let lit = LInteger 5
               term = App (V v0) $ V.singleton $ ELit lit
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsAlloc $ AllocLit lit)
                            (AnfTailCall $ AppFun v1 $ V.singleton v0)
           in toAnf term `shouldBe` anf
@@ -153,7 +154,7 @@ spec =
            let term = Let (V.replicate 2 dummyBI)
                           (Return $ V.fromList [ELit ten, V v0])
                           (Return $ V.fromList [V v0_1, V v0_0])
-               anf  = AnfLet (Arity 1)
+               anf  = AnfLet arity1
                              (RhsAlloc $ AllocLit ten)
                              (AnfReturn $ V.fromList [v1, v0])
            in toAnf term `shouldBe` anf
@@ -164,7 +165,7 @@ spec =
                          (V.singleton $
                            Delay $
                              App (V v0) $ V.singleton (V v0))
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $
                               AllocThunk $
                                AnfTailCall $ AppFun v0 $ V.singleton v0)
@@ -177,12 +178,12 @@ spec =
               term = App (EnterThunk (Delay $ V id_))
                          (V.singleton $ ELit ten)
               -- letA (delay id) in letA force (0) in letA 10 in letA (1) (0)
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $
                               AllocThunk $ AnfReturn $ V.singleton id_)
-                            (AnfLet (Arity 1)
+                            (AnfLet arity1
                                     (RhsApp $ AppThunk v0)
-                                    (AnfLet (Arity 1)
+                                    (AnfLet arity1
                                             (RhsAlloc $ AllocLit ten)
                                             (AnfTailCall $
                                               AppFun v1 $ V.singleton v0)))
@@ -192,7 +193,7 @@ spec =
           let term = App (V abs)
                          (V.singleton $ App (V v0)
                                             (V.fromList []))
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsApp $ AppFun v0 $ V.fromList [])
                             (AnfTailCall $ AppFun abs $ V.singleton v0)
           in toAnf term `shouldBe` anf
@@ -204,9 +205,9 @@ spec =
                          (V.singleton $ App (V neg)
                                             (V.singleton $ ELit lit))
               -- letA -10 in letA neg (0) in abs (0)
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsAlloc $ AllocLit lit)
-                           (AnfLet (Arity 1)
+                           (AnfLet arity1
                                    (RhsApp $ AppFun neg $ V.singleton v0)
                                    (AnfTailCall $ AppFun abs $ V.singleton v0))
           in toAnf term `shouldBe` anf
@@ -217,9 +218,9 @@ spec =
                          (V.singleton $ App (V v0)
                                             (V.fromList [ELit ten, V v0]))
               -- letA 10 in letA (1) (0) (1) in letA abs (0)
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $ AllocLit ten)
-                            (AnfLet (Arity 1)
+                            (AnfLet arity1
                                     (RhsApp $ AppFun v1 $ V.fromList [v0, v1])
                                     (AnfTailCall $ AppFun abs $ V.singleton v0))
           in toAnf term `shouldBe` anf
@@ -228,12 +229,12 @@ spec =
           let -- (prim0 10 (0)) 20
               term = App (PrimApp prim0 $ V.fromList [ELit ten, V v0])
                          (V.singleton $ ELit twenty)
-              anf  = AnfLet (Arity 1)
+              anf  = AnfLet arity1
                             (RhsAlloc $ AllocLit ten)
-                            (AnfLet (Arity 1)
+                            (AnfLet arity1
                                     (RhsApp $
                                       AppPrim prim0 (V.fromList [v0, v1]))
-                                    (AnfLet (Arity 1)
+                                    (AnfLet arity1
                                             (RhsAlloc $ AllocLit twenty)
                                             (AnfTailCall $
                                               AppFun v1 (V.singleton v0))))
@@ -247,10 +248,10 @@ spec =
                                                      (V.singleton $ V v0)))))
                          (V.singleton $ V v0)
               -- letA (λ. letA abs (0) in neg (0)) in (0) (1)
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsAlloc $
-                             AllocLam (Arity 1)
-                                      (AnfLet (Arity 1)
+                             AllocLam arity1
+                                      (AnfLet arity1
                                               (RhsApp $ AppFun abs $ V.singleton v0)
                                               (AnfTailCall $ AppFun neg $ V.singleton v0)))
                            (AnfTailCall $ AppFun v0 $ V.singleton v1)
@@ -267,13 +268,13 @@ spec =
                                         (V v1)))
                               (V.singleton $ V v0))
               -- letT 10 in letT 20 in letA (λ. (1)) in (0) (2)
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsAlloc $ AllocLit ten)
-                           (AnfLet (Arity 1)
+                           (AnfLet arity1
                                    (RhsAlloc $ AllocLit twenty)
-                                   (AnfLet (Arity 1)
+                                   (AnfLet arity1
                                            (RhsAlloc $
-                                             AllocLam (Arity 1)
+                                             AllocLam arity1
                                                       (AnfReturn $ V.singleton v1))
                                            (AnfTailCall $
                                              AppFun v0 $ V.singleton v2)))
@@ -287,7 +288,7 @@ spec =
                               (V v0))
                          (V.singleton $ ELit ten)
               -- letA 10 in add (0)
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsAlloc $ AllocLit ten)
                            (AnfTailCall $
                              AppFun add $ V.singleton v0)
@@ -303,11 +304,11 @@ spec =
                               (App (V id_) $ V.singleton $ V v0))
                          (App (V v0) $ V.singleton $ ELit ten)
               --  letT id abs in letT id (0) in letA 10 in (1) (0)
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsApp $ AppFun id_ $ V.singleton abs)
-                           (AnfLet (Arity 1)
+                           (AnfLet arity1
                                    (RhsApp $ AppFun id_ $ V.singleton v0)
-                                   (AnfLet (Arity 1)
+                                   (AnfLet arity1
                                            (RhsAlloc $ AllocLit ten)
                                            (AnfTailCall $ AppFun v1 $ V.singleton v0)))
           in toAnf term `shouldBe` anf
@@ -322,9 +323,9 @@ spec =
                               (V v1))
                          (App (V v0) $ V.singleton $ ELit ten)
               -- letT id abs in letA 10 in (2) (0)
-              anf = AnfLet (Arity 1)
+              anf = AnfLet arity1
                            (RhsApp $ AppFun id_ $ V.singleton abs)
-                           (AnfLet (Arity 1)
+                           (AnfLet arity1
                                    (RhsAlloc $ AllocLit ten)
                                    (AnfTailCall $ AppFun v2 $ V.singleton v0))
           in toAnf term `shouldBe` anf

--- a/tests/HopSpec/ClosureConversionSpec.hs
+++ b/tests/HopSpec/ClosureConversionSpec.hs
@@ -26,6 +26,7 @@ spec =
         v2 = LocalVar $ LocalNamelessVar 2 $ BinderSlot 0
         add = GlobalVarSym $ GlobalSymbol "add"
         ten = LInteger 10
+        twenty = LInteger 20
         dummyBI = BinderInfoData Omega () Nothing
         infos1 = V.singleton dummyBI
         infos2 = V.replicate 2 dummyBI
@@ -72,3 +73,42 @@ spec =
                                                      , record)])
                                       Map.empty
       in closureConvert anf `shouldBe` (ccd, registry)
+
+    -- TODO: test ordering of >1 closure env var
+
+    it "converts thunks" $
+      let anf = AnfLet infos1
+                       (RhsAlloc $ AllocLit ten)
+                       (AnfLet infos1
+                               (RhsAlloc $
+                                 AllocThunk $
+                                   AnfLet infos1
+                                          (RhsAlloc $ AllocLit twenty)
+                                          (AnfReturn $ V.fromList [v0, v1]))
+                               (AnfReturn $ V.singleton v0))
+          ccd = LetNFCC infos1
+                        (AllocRhsCC $ SharedLiteralCC ten)
+                        (LetNFCC infos1
+                                 (AllocRhsCC $
+                                   AllocateThunkCC (V.singleton v0)
+                                                   (ThunkCodeId 0))
+                                 (ReturnCC $ V.singleton v0))
+          record = ThunkCodeRecordCC (EnvSize 1)
+                                     infos1
+                                     (LetNFCC infos1
+                                              (AllocRhsCC $
+                                                SharedLiteralCC twenty)
+                                              (ReturnCC $
+                                                V.fromList [ v0 -- local let
+                                                           , v1 -- env slot 0
+                                                           ]))
+          registry = SymbolRegistryCC (Map.fromList [( (ThunkCodeId 0)
+                                                     , record)])
+                                      Map.empty
+                                      Map.empty
+      in closureConvert anf `shouldBe` (ccd, registry)
+
+    -- TODO: test ordering of >1 thunk env var
+
+    -- TODO: test nested closures/thunks; that only levels that need vars close
+    --       over them.

--- a/tests/HopSpec/ClosureConversionSpec.hs
+++ b/tests/HopSpec/ClosureConversionSpec.hs
@@ -50,8 +50,10 @@ spec =
                        (RhsAlloc $ AllocLit ten)
                        (AnfLet infos1
                                (RhsAlloc $
-                                 AllocLam infos1
-                                          (AnfReturn $ V.fromList [v0, v1]))
+                                 AllocLam infos1 $
+                                   AnfLet infos1
+                                          (RhsAlloc $ AllocLit twenty)
+                                          (AnfReturn $ V.fromList [v0, v1, v2]))
                                (AnfReturn $ V.singleton v0))
           ccd = LetNFCC infos1
                         (AllocRhsCC $ SharedLiteralCC ten)
@@ -65,11 +67,16 @@ spec =
                                        infos1 -- for env
                                        arity1
                                        infos1 -- for args
-                                       (ReturnCC $ V.fromList [ v1 -- arg slot 0
-                                                              , v0 -- env slot 0
-                                                              ])
+                                       (LetNFCC infos1
+                                                (AllocRhsCC $
+                                                  SharedLiteralCC twenty)
+                                                (ReturnCC $
+                                                  V.fromList [ v0 -- local var
+                                                             , v2 -- arg slot 0
+                                                             , v1 -- env slot 0
+                                                             ]))
           registry = SymbolRegistryCC Map.empty
-                                      (Map.fromList [( (ClosureCodeId 0)
+                                      (Map.fromList [( ClosureCodeId 0
                                                      , record)])
                                       Map.empty
       in closureConvert anf `shouldBe` (ccd, registry)
@@ -102,7 +109,7 @@ spec =
                                                 V.fromList [ v0 -- local let
                                                            , v1 -- env slot 0
                                                            ]))
-          registry = SymbolRegistryCC (Map.fromList [( (ThunkCodeId 0)
+          registry = SymbolRegistryCC (Map.fromList [( ThunkCodeId 0
                                                      , record)])
                                       Map.empty
                                       Map.empty

--- a/tests/HopSpec/ClosureConversionSpec.hs
+++ b/tests/HopSpec/ClosureConversionSpec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module HopSpec.ClosureConversionSpec
+  ( spec
+  ) where
+
+import Hopper.Internal.LoweredCore.ANF
+import Hopper.Internal.LoweredCore.ClosureConversion (closureConvert)
+import Hopper.Internal.LoweredCore.ClosureConvertedANF
+import Hopper.Internal.Core.Literal
+import Hopper.Internal.Type.Relevance
+import Hopper.Internal.Type.BinderInfo
+import Hopper.Utils.LocallyNameless
+
+import Test.Hspec
+import Test.Hspec.Expectations
+
+import qualified Data.Vector as V
+import qualified Data.Map as Map
+
+spec :: Spec
+spec =
+  describe "Closure conversion" $ do
+    let v0 = LocalVar $ LocalNamelessVar 0 $ BinderSlot 0
+        v1 = LocalVar $ LocalNamelessVar 1 $ BinderSlot 0
+        v2 = LocalVar $ LocalNamelessVar 2 $ BinderSlot 0
+        add = GlobalVarSym $ GlobalSymbol "add"
+        ten = LInteger 10
+        dummyBI = BinderInfoData Omega () Nothing
+        arity1 = V.singleton $ dummyBI
+        emptyRegistry = SymbolRegistryCC Map.empty Map.empty Map.empty
+        -- prim0 = PrimopIdGeneral "test"
+
+    it "handles trivial closureless-code" $
+      let anf = AnfLet arity1
+                       (RhsAlloc $ AllocLit ten)
+                       (AnfReturn $ V.singleton v0)
+          ccd = LetNFCC arity1
+                        (AllocRhsCC $ SharedLiteralCC ten)
+                        (ReturnCC $ V.singleton v0)
+      in closureConvert anf `shouldBe` (ccd, emptyRegistry)

--- a/tests/HopSpec/ClosureConversionSpec.hs
+++ b/tests/HopSpec/ClosureConversionSpec.hs
@@ -27,15 +27,48 @@ spec =
         add = GlobalVarSym $ GlobalSymbol "add"
         ten = LInteger 10
         dummyBI = BinderInfoData Omega () Nothing
-        arity1 = V.singleton $ dummyBI
+        infos1 = V.singleton dummyBI
+        infos2 = V.replicate 2 dummyBI
+        arity1 = CodeArity 1
+        -- arity2 = CodeArity 2
         emptyRegistry = SymbolRegistryCC Map.empty Map.empty Map.empty
         -- prim0 = PrimopIdGeneral "test"
 
     it "handles trivial closureless-code" $
-      let anf = AnfLet arity1
+      let anf = AnfLet infos1
                        (RhsAlloc $ AllocLit ten)
                        (AnfReturn $ V.singleton v0)
-          ccd = LetNFCC arity1
+          ccd = LetNFCC infos1
                         (AllocRhsCC $ SharedLiteralCC ten)
                         (ReturnCC $ V.singleton v0)
-      in closureConvert anf `shouldBe` (ccd, emptyRegistry)
+          registry = emptyRegistry
+      in closureConvert anf `shouldBe` (ccd, registry)
+
+    it "converts closures" $
+      let anf = AnfLet infos1
+                       (RhsAlloc $ AllocLit ten)
+                       (AnfLet infos1
+                               (RhsAlloc $
+                                 AllocLam infos1
+                                          (AnfReturn $ V.fromList [v0, v1]))
+                               (AnfReturn $ V.singleton v0))
+          ccd = LetNFCC infos1
+                        (AllocRhsCC $ SharedLiteralCC ten)
+                        (LetNFCC infos1
+                                 (AllocRhsCC $
+                                   AllocateClosureCC (V.singleton v0)
+                                                     arity1
+                                                     (ClosureCodeId 0))
+                                 (ReturnCC $ V.singleton v0))
+          record = ClosureCodeRecordCC (EnvSize 1)
+                                       infos1 -- for env
+                                       arity1
+                                       infos1 -- for args
+                                       (ReturnCC $ V.fromList [ v1 -- arg slot 0
+                                                              , v0 -- env slot 0
+                                                              ])
+          registry = SymbolRegistryCC Map.empty
+                                      (Map.fromList [( (ClosureCodeId 0)
+                                                     , record)])
+                                      Map.empty
+      in closureConvert anf `shouldBe` (ccd, registry)

--- a/tests/HopSpec/ClosureConversionSpec.hs
+++ b/tests/HopSpec/ClosureConversionSpec.hs
@@ -35,13 +35,19 @@ spec =
         emptyRegistry = SymbolRegistryCC Map.empty Map.empty Map.empty
         -- prim0 = PrimopIdGeneral "test"
 
-    it "handles trivial closureless-code" $
+    it "handles closure-less let and return" $
       let anf = AnfLet infos1
                        (RhsAlloc $ AllocLit ten)
                        (AnfReturn $ V.singleton v0)
           ccd = LetNFCC infos1
                         (AllocRhsCC $ SharedLiteralCC ten)
                         (ReturnCC $ V.singleton v0)
+          registry = emptyRegistry
+      in closureConvert anf `shouldBe` (ccd, registry)
+
+    it "allows free vars" $
+      let anf = AnfReturn $ V.singleton v1
+          ccd = ReturnCC $ V.singleton v1
           registry = emptyRegistry
       in closureConvert anf `shouldBe` (ccd, registry)
 
@@ -81,8 +87,6 @@ spec =
                                       Map.empty
       in closureConvert anf `shouldBe` (ccd, registry)
 
-    -- TODO: test ordering of >1 closure env var
-
     it "converts thunks" $
       let anf = AnfLet infos1
                        (RhsAlloc $ AllocLit ten)
@@ -115,7 +119,11 @@ spec =
                                       Map.empty
       in closureConvert anf `shouldBe` (ccd, registry)
 
-    -- TODO: test ordering of >1 thunk env var
+    it "allocates env vars from left to right" $
+      pending
 
-    -- TODO: test nested closures/thunks; that only levels that need vars close
-    --       over them.
+    it "only allocates an env var if a var is used in that closure" $
+      pending
+
+    it "converts nested closures and thunks" $
+      pending

--- a/tests/HopSpec/EvalSpec.hs
+++ b/tests/HopSpec/EvalSpec.hs
@@ -86,7 +86,7 @@ spec = describe "Evaluation Spec" $ do
     --   <empty> (halt when the tail call returns)
     --
     -- environment stack:
-    --   1
+    --   1  <- top
     --   id
     let idRef = Ref 0
         numRef = Ref 1


### PR DESCRIPTION
@joelburget @cartazio

- Change ANF conversion to use `V.Vector BinderInfo` instead of `Arity`
- Implement closure conversion pass from `Anf` to `AnfCC`, with tests
- Change evaluator to use new two-level ABI (args on the outer, and closure/thunk environment on the inner level)